### PR TITLE
VEOSS-846 | Updated specs for RSS feed errors

### DIFF
--- a/app/uk/gov/hmrc/forexrates/controllers/test/TestOnlyController.scala
+++ b/app/uk/gov/hmrc/forexrates/controllers/test/TestOnlyController.scala
@@ -42,9 +42,6 @@ class TestOnlyController @Inject()(
         logger.warn("Did not retrieve rates from stub")
         NotFound
       }
-
-
     }
   }
-
 }

--- a/test/uk/gov/hmrc/forexrates/connectors/EcbForexConnectorSpec.scala
+++ b/test/uk/gov/hmrc/forexrates/connectors/EcbForexConnectorSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.concurrent.IntegrationPatience
 import org.xml.sax.SAXParseException
 import play.api.Application
 import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR, NOT_FOUND}
+import play.api.libs.json.Json
 import play.api.test.Helpers.running
 import uk.gov.hmrc.forexrates.models.ExchangeRate
 import uk.gov.hmrc.forexrates.testutils.EcbForexData
@@ -47,6 +48,7 @@ class EcbForexConnectorSpec extends SpecBase with WireMockHelper with Integratio
   val errorStatuses = Seq(BAD_REQUEST, NOT_FOUND, INTERNAL_SERVER_ERROR)
 
   "EcbForexConnector get" - {
+
     "return feed items" in {
       val app = application
 
@@ -72,7 +74,8 @@ class EcbForexConnectorSpec extends SpecBase with WireMockHelper with Integratio
       }
     }
 
-    "throw exception xml is invalid" in {
+    "return empty sequence and log the error when xml received from ecb cannot be parsed" in {
+
       val app = application
 
       server.stubFor(
@@ -85,9 +88,9 @@ class EcbForexConnectorSpec extends SpecBase with WireMockHelper with Integratio
 
       running(app) {
         val connector = app.injector.instanceOf[EcbForexConnector]
-        val result = connector.getFeed("GBP")
+        val result = connector.getFeed("GBP").futureValue
 
-        whenReady(result.failed) { exp => exp mustBe a[SAXParseException] }
+        result mustBe Seq.empty
       }
     }
 

--- a/test/uk/gov/hmrc/forexrates/controllers/ForexRatesControllerSpec.scala
+++ b/test/uk/gov/hmrc/forexrates/controllers/ForexRatesControllerSpec.scala
@@ -6,6 +6,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.MockitoSugar.when
 import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import play.api.http.Status.OK
 import play.api.inject.bind
 import play.api.libs.json.{JsArray, Json}

--- a/test/uk/gov/hmrc/forexrates/services/EcbForexServiceSpec.scala
+++ b/test/uk/gov/hmrc/forexrates/services/EcbForexServiceSpec.scala
@@ -1,26 +1,29 @@
 package uk.gov.hmrc.forexrates.services
 
+import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, anyUrl, get, urlEqualTo}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalacheck.Arbitrary.arbitrary
 import org.mockito.ArgumentMatchersSugar.eqTo
 import org.mockito.Mockito
 import org.scalatest.BeforeAndAfterEach
+import play.api.inject.bind
 import uk.gov.hmrc.forexrates.base.SpecBase
 import uk.gov.hmrc.forexrates.config.AppConfig
-import uk.gov.hmrc.forexrates.connectors.EcbForexConnector
+import uk.gov.hmrc.forexrates.connectors.{EcbForexConnector, WireMockHelper}
 import uk.gov.hmrc.forexrates.models.ExchangeRate
 import uk.gov.hmrc.forexrates.repositories.ForexRepository
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class EcbForexServiceSpec extends SpecBase with BeforeAndAfterEach {
+class EcbForexServiceSpec extends SpecBase with WireMockHelper with BeforeAndAfterEach {
 
   private val mockEcbForexConnector = mock[EcbForexConnector]
   private val mockForexRepository = mock[ForexRepository]
   private val mockAppConfig = mock[AppConfig]
   private val service: EcbForexServiceImpl = new EcbForexServiceImpl(mockEcbForexConnector, mockForexRepository, mockAppConfig)
+
 
   override def beforeEach(): Unit = {
     Mockito.reset(mockEcbForexConnector, mockForexRepository)
@@ -52,6 +55,38 @@ class EcbForexServiceSpec extends SpecBase with BeforeAndAfterEach {
       when(mockAppConfig.currencies) thenReturn currencies
       when(mockEcbForexConnector.getFeed(eqTo(currency1))) thenReturn Future.successful(Seq.empty)
       service.triggerFeedUpdate().futureValue mustBe Seq.empty
+      verifyNoInteractions(mockForexRepository)
+    }
+
+    "must handle errors from ECB feed" in {
+      when(mockAppConfig.currencies) thenReturn currencies
+      when(mockEcbForexConnector.getFeed(eqTo(currency1))) thenReturn Future.successful(Seq.empty)
+      service.triggerFeedUpdate().futureValue mustBe Seq.empty
+      verifyNoInteractions(mockForexRepository)
+    }
+
+    "must handle XML parsing errors gracefully" in {
+
+      val url = "/ecb-forex-rss-stub/rss/fxref-gbp.html"
+
+      val app = applicationBuilder.configure(
+        "microservice.services.ecb-forex.protocol" -> "http",
+        "microservice.services.ecb-forex.host" -> "127.0.0.1",
+        "microservice.services.ecb-forex.port" -> server.port,
+        "microservice.services.ecb-forex.basePath" -> "ecb-forex-rss-stub"
+      ).build()
+
+      server.stubFor(
+        get(urlEqualTo(url))
+          .willReturn(aResponse()
+            .withStatus(200)
+            .withBody("invalid body")
+          )
+      )
+
+      val serv = app.injector.instanceOf[EcbForexServiceImpl]
+
+      serv.triggerFeedUpdate().futureValue mustBe Seq.empty
       verifyNoInteractions(mockForexRepository)
     }
   }


### PR DESCRIPTION
Agreed with Andrew Smith and Susan Badel that best approach for testing unsuccessful responses from RSS feed is in the forex-rates spec tests instead of stubbing.

Errors from RSS feed mostly covered, but added exception handling for XML parsing errors.